### PR TITLE
Migrate to v2 api

### DIFF
--- a/chat
+++ b/chat
@@ -332,7 +332,7 @@ add-assistant() {
 
   description=$(gum input --prompt 'Enter an optional description: ' --placeholder 'Gene Peetee, the helpful chatbot.')
 
-  tools="$(gum choose --header 'Select any add-on tools you want available to the assistant' --no-limit {none,code_interpreter,retrieval,function})" || true
+  tools="$(gum choose --header 'Select any add-on tools you want available to the assistant' --no-limit {none,code_interpreter,file_search,function})" || true
   tools=$(echo "$tools" | sed '/^none$/d;/^$/d')
 
   ASSISTANT_ID=$(create-assistant "$name" "$instructions" "$description" "$tools")

--- a/chat
+++ b/chat
@@ -591,8 +591,6 @@ attach-file() {
           # shellcheck disable=SC2016
           msg=$(printf 'Attached file content: `%s` (part %s)\n```\n%s\n```\n' "$filepath" "$part_no" "$chunk")
           echo -e "$msg" | base64
-
-          sleep 1 # Adding a short delay to avoid rapid message sending
         done < <(split-into-chunks "$MAX_FILE_SIZE" "$content")
 
         return 0
@@ -649,14 +647,14 @@ attach-command-output() {
       # shellcheck disable=SC2016
       msg=$(printf 'Command `%s` output continued (part %s):\n```\n%s\n```' "$command" "$part_no" "$chunk")
       echo -e "$msg" | base64
-
-      sleep 1 # Adding a short delay to avoid rapid message sending
     done < <(split-into-chunks "$MAX_MSG_SIZE" "$command_output")
-  else
-    # shellcheck disable=SC2016
-    msg=$(printf 'Command `%s` output:\n```\n%s\n```' "$command" "$command_output")
-    echo -e "$msg" | base64
+
+    return 0
   fi
+
+  # shellcheck disable=SC2016
+  msg=$(printf 'Command `%s` output:\n```\n%s\n```' "$command" "$command_output")
+  echo -e "$msg" | base64
 }
 
 # ------------------------------------------------------------------------------
@@ -702,11 +700,13 @@ attach-web-content() {
 
       sleep 1 # Adding a short delay to avoid rapid message sending
     done < <(split-into-chunks "$MAX_MSG_SIZE" "$content")
-  else
-    # shellcheck disable=SC2016
-    msg=$(printf 'Attached web content: `%s`\n```\n%s\n```\n' "$url" "$content")
-    echo -e "$msg" | base64
+
+    return 0
   fi
+
+  # shellcheck disable=SC2016
+  msg=$(printf 'Attached web content: `%s`\n```\n%s\n```\n' "$url" "$content")
+  echo -e "$msg" | base64
 }
 
 # ------------------------------------------------------------------------------
@@ -869,16 +869,12 @@ handle-parsed-message() {
         readarray -t msgs < <(attach-command-output "$exec_line")
         info "✓"
 
-        messages+=('```')
-
         for msg in "${msgs[@]}"; do
           msg=$(base64 --decode <<< "$msg")
           if [ -n "$msg" ]; then
             messages+=("$msg")
           fi
         done
-
-        messages+=('```')
         ;;
 
       FILE*)

--- a/chat
+++ b/chat
@@ -125,19 +125,9 @@ create-assistant() {
   local name="$1"
   local instructions="$2"
   local description="$3"
-  local tools=()
-  local tool_args=()
-
-  # gum choose returns a space-separated list of selected tools, so we read it into an array
-  IFS=' ' read -r -a tools <<< "$4"
-
-  # Build the tool arguments
-  for tool in "${tools[@]}"; do
-    [[ -n "$tool" ]] && tool_args+=(--tool "$tool")
-  done
 
   # Now include the tool arguments in the openai invocation
-  if ! result=$(openai create-assistant --name "$name" --instructions "$instructions" --description "$description" "${tool_args[@]}" 2>&1); then
+  if ! result=$(openai create-assistant --name "$name" --instructions "$instructions" --description "$description" 2>&1); then
     die "$result"
   fi
 
@@ -152,19 +142,7 @@ modify-assistant() {
   local name="$1"
   local instructions="$2"
   local description="$3"
-  local tools=()
-  local tool_args=()
-  local tool
   local result
-
-  # `gum choose` returns a space-separated list of selected tools, so we read
-  # it into an array that we can turn into multiple --tool arguments to openai.
-  IFS=' ' read -r -a tools <<< "$4"
-
-  # Build the tool arguments
-  for tool in "${tools[@]}"; do
-    [[ -n "$tool" ]] && tool_args+=(--tool "$tool")
-  done
 
   # Now include the tool arguments in the openai invocation
   if ! result=$(
@@ -173,7 +151,6 @@ modify-assistant() {
       --name "$name" \
       --instructions "$instructions" \
       --description "$description" \
-      "${tool_args[@]}" \
       2>&1
   ); then
     die "$result"
@@ -305,7 +282,6 @@ add-assistant() {
   local name
   local instructions
   local description
-  local tools
 
   name=$(gum input --prompt 'Enter a name for the assistant: ' --placeholder 'G. Peetee') || return 0
 
@@ -332,10 +308,7 @@ add-assistant() {
 
   description=$(gum input --prompt 'Enter an optional description: ' --placeholder 'Gene Peetee, the helpful chatbot.')
 
-  tools="$(gum choose --header 'Select any add-on tools you want available to the assistant' --no-limit {none,code_interpreter,file_search,function})" || true
-  tools=$(echo "$tools" | sed '/^none$/d;/^$/d')
-
-  ASSISTANT_ID=$(create-assistant "$name" "$instructions" "$description" "$tools")
+  ASSISTANT_ID=$(create-assistant "$name" "$instructions" "$description")
   ASSISTANT_NAME="$name"
 
   save-selected-assistant
@@ -351,12 +324,10 @@ edit-assistant() {
   local name
   local instructions
   local description
-  local tools
 
   local new_name
   local new_instructions
   local new_description
-  local new_tools
 
   if ! result=$(openai get-assistant --assistant "$ASSISTANT_ID"); then
     warn "error getting assistant"
@@ -366,7 +337,6 @@ edit-assistant() {
   name=$(jq -r '.name' <<< "$result")
   instructions=$(jq -r '.instructions' <<< "$result")
   description=$(jq -r '.description' <<< "$result")
-  tools=$(jq -r '.tools | map(.type) | join(" ")' <<< "$result")
 
   if ! new_name=$(gum input --prompt 'Enter a new name: ' --value "$name"); then
     return
@@ -380,20 +350,14 @@ edit-assistant() {
     return
   fi
 
-  if ! new_tools=$(gum choose --header 'Update selected tools' --no-limit --selected "$tools" {none,code_interpreter,retrieval,function}); then
-    return
-  fi
-
-  new_tools=$(echo "$new_tools" | sed '/^none$/d;/^$/d')
-
   if [ -z "$new_name" ] || [ -z "$new_instructions" ]; then
     # The user pressed escape on name or instructions, so we skip updating the
-    # description and tools.
+    # description.
     new_name=$name
     new_instructions=$instructions
   fi
 
-  ASSISTANT_ID=$(modify-assistant "$new_name" "$new_instructions" "$new_description" "$new_tools")
+  ASSISTANT_ID=$(modify-assistant "$new_name" "$new_instructions" "$new_description")
   ASSISTANT_NAME="$new_name"
 
   save-selected-assistant

--- a/chat
+++ b/chat
@@ -125,9 +125,17 @@ create-assistant() {
   local name="$1"
   local instructions="$2"
   local description="$3"
+  local model="$4"
 
   # Now include the tool arguments in the openai invocation
-  if ! result=$(openai create-assistant --name "$name" --instructions "$instructions" --description "$description" 2>&1); then
+  if ! result=$(
+    openai create-assistant \
+      --name "$name" \
+      --instructions "$instructions" \
+      --description "$description" \
+      --model "$model" \
+      2>&1
+  ); then
     die "$result"
   fi
 
@@ -142,6 +150,7 @@ modify-assistant() {
   local name="$1"
   local instructions="$2"
   local description="$3"
+  local model="$4"
   local result
 
   # Now include the tool arguments in the openai invocation
@@ -151,6 +160,7 @@ modify-assistant() {
       --name "$name" \
       --instructions "$instructions" \
       --description "$description" \
+      --model "$model" \
       2>&1
   ); then
     die "$result"
@@ -274,6 +284,24 @@ list-messages() {
 # ------------------------------------------------------------------------------
 # Feature: ASSISTANTS
 # ------------------------------------------------------------------------------
+list-models() {
+  curl -s "https://api.openai.com/v1/models" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    | jq -r '.data.[].id' \
+    | grep gpt \
+    | sort
+}
+
+select-model() {
+  local model="${1:-"$OPENAI_MODEL"}"
+  local models=()
+
+  while IFS=':' read -r name; do
+    models+=("$name")
+  done < <(list-models)
+
+  gum choose --header "Select a model" --selected "$model" "${models[@]}" || return 0
+}
 
 # ------------------------------------------------------------------------------
 # Creates a new custom GPT model and emits its id.
@@ -282,6 +310,7 @@ add-assistant() {
   local name
   local instructions
   local description
+  local model
 
   name=$(gum input --prompt 'Enter a name for the assistant: ' --placeholder 'G. Peetee') || return 0
 
@@ -308,7 +337,10 @@ add-assistant() {
 
   description=$(gum input --prompt 'Enter an optional description: ' --placeholder 'Gene Peetee, the helpful chatbot.')
 
-  ASSISTANT_ID=$(create-assistant "$name" "$instructions" "$description")
+  # shellcheck disable=SC2119
+  model=$(select-model)
+
+  ASSISTANT_ID=$(create-assistant "$name" "$instructions" "$description" "$model")
   ASSISTANT_NAME="$name"
 
   save-selected-assistant
@@ -324,10 +356,12 @@ edit-assistant() {
   local name
   local instructions
   local description
+  local model
 
   local new_name
   local new_instructions
   local new_description
+  local new_model
 
   if ! result=$(openai get-assistant --assistant "$ASSISTANT_ID"); then
     warn "error getting assistant"
@@ -337,6 +371,7 @@ edit-assistant() {
   name=$(jq -r '.name' <<< "$result")
   instructions=$(jq -r '.instructions' <<< "$result")
   description=$(jq -r '.description' <<< "$result")
+  model=$(jq -r '.model' <<< "$result")
 
   if ! new_name=$(gum input --prompt 'Enter a new name: ' --value "$name"); then
     return
@@ -350,6 +385,10 @@ edit-assistant() {
     return
   fi
 
+  if ! new_model=$(select-model "$model"); then
+    return
+  fi
+
   if [ -z "$new_name" ] || [ -z "$new_instructions" ]; then
     # The user pressed escape on name or instructions, so we skip updating the
     # description.
@@ -357,7 +396,7 @@ edit-assistant() {
     new_instructions=$instructions
   fi
 
-  ASSISTANT_ID=$(modify-assistant "$new_name" "$new_instructions" "$new_description")
+  ASSISTANT_ID=$(modify-assistant "$new_name" "$new_instructions" "$new_description" "$new_model")
   ASSISTANT_NAME="$new_name"
 
   save-selected-assistant

--- a/openai
+++ b/openai
@@ -39,25 +39,12 @@ usage: $PROGRAM [OPTIONS]
 
 # Commands:
 
-## Files
-  * list-files            list files
-  * get-file              get info about a file
-  * upload-file           upload a file
-  * retrieve-file         retrieve a file's contents
-  * delete-file           delete a file
-
 ## Assistant
   * create-assistant      create a new assistant
   * modify-assistant      modify an existing assistant
   * list-assistants       list assistants
   * get-assistant         get info about an assistant
   * delete-assistant      delete an assistant
-
-## Assistant files
-  * add-assistant-file    add a file to an assistant
-  * list-assistant-files  list files in an assistant
-  * get-assistant-file    get info about a file in an assistant
-  * delete-assistant-file delete a file from an assistant
 
 ## Threads
   * start-thread          start a new thread
@@ -77,10 +64,6 @@ usage: $PROGRAM [OPTIONS]
   * get-run               get info about a thread's run
   * modify-run            modify a thread's run
   * cancel-run            cancel a thread's run
-
-## Run steps
-  * list-steps            list steps for a thread's run
-  * get-step              get info about a thread's run step
 
 ## Completions
   * get-completion        generate a chat completion (non-streaming)
@@ -126,6 +109,7 @@ cmd-usage() {
         ;;
 
       MODEL)
+        # shellcheck disable=SC2016
         collected+=('--model' 'the model to use (default: $OPENAI_MODEL)')
         ;;
 
@@ -145,10 +129,6 @@ cmd-usage() {
         collected+=('--run' 'the id of the run (required)')
         ;;
 
-      STEP)
-        collected+=('--step' 'the id of the step (required)')
-        ;;
-
       MESSAGE)
         collected+=('--message' 'the id of the message (required)')
         ;;
@@ -165,28 +145,12 @@ cmd-usage() {
         collected+=('--description' 'the description of the assistant')
         ;;
 
-      FILE)
-        collected+=('--file' 'the id of the file (required)')
-        ;;
-
-      FILEPATH)
-        collected+=('--file' 'the path to the file (required)')
-        ;;
-
       CONTENT)
         collected+=('--content' 'the message to add (required)')
         ;;
 
-      'FILE[]')
-        collected+=('--file' 'the id of files to include; can be specified multiple times')
-        ;;
-
       'META[]')
         collected+=('--meta' 'the metadata to include; up to 16 key/value pairs are permitted (e.g. --meta key1=value1 --meta key2=value2)')
-        ;;
-
-      'TOOLS[]')
-        collected+=('--tools' 'the name of tools to enable; can be specified multiple times; current options are "code_interpreter", "file_search", and "function"')
         ;;
 
       *)
@@ -422,156 +386,21 @@ build-paginated-uri() {
 # ------------------------------------------------------------------------------
 # Commands
 # ------------------------------------------------------------------------------
-cmd:list-files() {
-  if wants-help "$@"; then
-    cmd-usage 'list-files'
-  fi
-
-  request "$API_BASE_URI/files"
-}
-
-cmd:get-file() {
-  local file_id
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'get-file' 'FILE'
-  fi
-
-  file_id=$(get-config --file "$@") || die "get-file: expected --file"
-
-  request "$API_BASE_URI/files/$file_id"
-}
-
-cmd:upload-file() {
-  local file
-  local purpose
-  local mime
-  local temp_file=""
-  local supported_types
-  local is_supported
-  local file_name
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'upload-file' 'FILEPATH' --purpose 'the purpose of the file (default: assistants; allowed: fine-tune|assistants)'
-  fi
-
-  file=$(get-config --file "$@") || die "upload-file: expected --file"
-  purpose=$(get-config --purpose "$@") || true
-
-  file_name=$(basename "$file")
-  mime=$(file --mime-type -b "$file")
-
-  if [ ! -f "$file" ]; then
-    die "upload-file: file does not exist - $file"
-  fi
-
-  if [ -z "$purpose" ]; then
-    purpose="assistants"
-  fi
-
-  # List of supported mime types
-  supported_types=(
-    "application/json"
-    "application/msword"
-    "application/pdf"
-    "application/vnd.ms-excel"
-    "application/vnd.ms-powerpoint"
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-    "application/x-tar"
-    "application/xml"
-    "application/zip"
-    "image/gif"
-    "image/jpeg"
-    "image/png"
-    "text/css"
-    "text/csv"
-    "text/html"
-    "text/javascript"
-    "text/markdown"
-    "text/plain"
-    "text/x-c++src"
-    "text/x-csrc"
-    "text/x-java-source"
-    "text/x-php"
-    "text/x-python-script"
-    "text/x-ruby"
-    "text/x-tex"
-  )
-
-  # Check if mime type is supported
-  is_supported=false
-  for supported_mime in "${supported_types[@]}"; do
-    if [[ $mime == "$supported_mime" ]]; then
-      is_supported=true
-      break
-    fi
-  done
-
-  # Fudge it as a test file if possible
-  if [[ $is_supported == false ]]; then
-    warn "$mime is not a supported mime type, attempting to upload as text/plain"
-    temp_file="/tmp/${file_name}.txt"
-    cp "$file" "$temp_file"
-    file="$temp_file"
-    mime="text/plain"
-  fi
-
-  request "$API_BASE_URI/files" \
-    -H 'Content-Type: multipart/form-data' \
-    -F purpose="$purpose" \
-    -F file="@$file"
-
-  # Clean up temporary file if created
-  if [ -n "$temp_file" ]; then
-    rm "$temp_file"
-  fi
-}
-
-cmd:delete-file() {
-  local file
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'delete-file' 'FILE'
-  fi
-
-  file=$(get-config --file "$@") || die "delete-file: expected --file"
-
-  request "$API_BASE_URI/files/$file" -X DELETE
-}
-
-cmd:retrieve-file() {
-  local file
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'retrieve-file' 'FILE'
-  fi
-
-  file=$(get-config --file "$@") || die "retrieve-file: expected --file"
-
-  request "$API_BASE_URI/files/$file/content"
-}
-
 cmd:create-assistant() {
   local name
   local instructions
   local description
   local model
   local payload
-  local files=()
-  local tools=()
 
   if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'create-assistant' 'NAME' 'DESCRIPTION' 'INSTRUCTIONS' 'MODEL' 'FILE[]' 'META[]' 'TOOLS[]'
+    cmd-usage 'create-assistant' 'NAME' 'DESCRIPTION' 'INSTRUCTIONS' 'MODEL' 'META[]'
   fi
 
   name=$(get-config --name "$@") || die "create-assistant: expected --name"
   instructions=$(get-config --instructions "$@") || die "create-assistant: expected --instructions"
   description=$(get-config --description "$@") || true
   model=$(get-config --model "$@") || true
-  get-config-multi --tools tools "$@" || true
-  get-config-multi --file files "$@" || true
 
   if [ -z "$model" ]; then
     model="$OPENAI_MODEL"
@@ -587,14 +416,6 @@ cmd:create-assistant() {
     payload=$(jq --arg x "$description" '. + {"description": $x}' <<< "$payload")
   fi
 
-  if [[ ${#files[@]} -gt 0 ]]; then
-    payload=$(jq --argjson x "$(printf '%s\n' "${files[@]}" | jq -R . | jq -s .)" '. + {file_ids: $x}' <<< "$payload")
-  fi
-
-  if [[ ${#tools[@]} -gt 0 ]]; then
-    payload=$(jq --argjson tools "$(printf '%s\n' "${tools[@]}" | jq -R '{type: .}' | jq -s .)" '. + {tools: $tools}' <<< "$payload")
-  fi
-
   request "$API_BASE_URI/assistants" -d "$payload"
 }
 
@@ -605,11 +426,9 @@ cmd:modify-assistant() {
   local description
   local model
   local payload
-  local files=()
-  local tools=()
 
   if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'modify-assistant' 'ASSISTANT' 'NAME' 'DESCRIPTION' 'INSTRUCTIONS' 'MODEL' 'TOOLS[]' 'FILE[]' 'META[]'
+    cmd-usage 'modify-assistant' 'ASSISTANT' 'NAME' 'DESCRIPTION' 'INSTRUCTIONS' 'MODEL' 'META[]'
   fi
 
   assistant=$(get-config --assistant "$@") || die "modify-assistant: expected --assistant"
@@ -617,8 +436,6 @@ cmd:modify-assistant() {
   instructions=$(get-config --instructions "$@") || true
   description=$(get-config --description "$@") || true
   model=$(get-config --model "$@") || true
-  get-config-multi --tools tools "$@" || true
-  get-config-multi --file files "$@" || true
 
   if [ -z "$model" ]; then
     model="$OPENAI_MODEL"
@@ -641,14 +458,6 @@ cmd:modify-assistant() {
 
   if [ -n "$description" ]; then
     payload=$(jq --arg x "$description" '. + {"description": $x}' <<< "$payload")
-  fi
-
-  if [[ ${#files[@]} -gt 0 ]]; then
-    payload=$(jq --argjson x "$(printf '%s\n' "${files[@]}" | jq -R . | jq -s .)" '. + {file_ids: $x}' <<< "$payload")
-  fi
-
-  if [[ ${#tools[@]} -gt 0 ]]; then
-    payload=$(jq --argjson tools "$(printf '%s\n' "${tools[@]}" | jq -R '{type: .}' | jq -s .)" '. + {tools: $tools}' <<< "$payload")
   fi
 
   request "$API_BASE_URI/assistants/$assistant" -d "$payload"
@@ -691,71 +500,6 @@ cmd:delete-assistant() {
 
   assistant=$(get-config --assistant "$@") || die "delete-assistant: expected --assistant"
   request "$API_BASE_URI/assistants/$assistant" -X DELETE
-}
-
-cmd:add-assistant-file() {
-  local assistant
-  local file
-  local payload
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'add-assistant-file' 'ASSISTANT' 'FILE'
-  fi
-
-  assistant=$(get-config --assistant "$@") || die "add-assistant-file: expected --assistant"
-  file=$(get-config --file "$@") || die "add-assistant-file: expected --file"
-
-  payload=$(jq -n '{}')
-  payload=$(jq --arg x "$file" '. + {"file_id": $x}' <<< "$payload")
-
-  request "$API_BASE_URI/assistants/$assistant/files" -d "$payload"
-}
-
-cmd:get-assistant-file() {
-  local assistant
-  local file
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'get-assistant-file' 'ASSISTANT' 'FILE'
-  fi
-
-  assistant=$(get-config --assistant "$@") || die "get-assistant-file: expected --assistant"
-  file=$(get-config --file "$@") || die "get-assistant-file: expected --file"
-
-  request "$API_BASE_URI/assistants/$assistant/files/$file"
-}
-
-cmd:delete-assistant-file() {
-  local assistant
-  local file
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'delete-assistant-file' 'ASSISTANT' 'FILE'
-  fi
-
-  assistant=$(get-config --assistant "$@") || die "get-assistant-file: expected --assistant"
-  file=$(get-config --file "$@") || die "get-assistant-file: expected --file"
-
-  request "$API_BASE_URI/assistants/$assistant/files/$file" -X DELETE
-}
-
-cmd:list-assistant-files() {
-  local assistant
-  local order
-  local limit
-  local after
-  local before
-  local query
-  local endpoint
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'list-assistant-files' 'PAGINATION' 'ASSISTANT'
-  fi
-
-  assistant=$(get-config --assistant "$@") || die "list-assistant-files: expected --assistant"
-  endpoint=$(build-paginated-uri "$API_BASE_URI/assistants/$assistant/files" "$@")
-
-  request "$endpoint"
 }
 
 cmd:start-thread() {
@@ -816,22 +560,15 @@ cmd:add-message() {
   local content
   local payload
 
-  declare -a files
-
   if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'add-message' 'THREAD' 'FILE[]' 'CONTENT'
+    cmd-usage 'add-message' 'THREAD' 'CONTENT'
   fi
 
   thread=$(get-config --thread "$@") || die "add-message: expected --thread"
   content=$(get-config --content "$@") || die "add-message: expected --content"
-  get-config-multi --file files "$@" || true
 
   payload=$(jq -n '{"role": "user"}')
   payload=$(jq --arg x "$content" '. + {"content": $x}' <<< "$payload")
-
-  if [[ ${#files[@]} -gt 0 ]]; then
-    payload=$(jq --argjson x "$(printf '%s\n' "${files[@]}" | jq -R . | jq -s .)" '. + {file_ids: $x}' <<< "$payload")
-  fi
 
   request "$API_BASE_URI/threads/$thread/messages" -d "$payload"
 }
@@ -960,36 +697,6 @@ cmd:cancel-run() {
   run=$(get-config --run "$@") || die "cancel-run: expected --run"
 
   request "$API_BASE_URI/threads/$thread/runs/$run/cancel" -X POST
-}
-
-cmd:list-steps() {
-  local thread
-  local run
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'list-steps' 'THREAD' 'RUN'
-  fi
-
-  thread=$(get-config --thread "$@") || die "list-steps: expected --thread"
-  run=$(get-config --run "$@") || die "list-steps: expected --run"
-
-  request "$API_BASE_URI/threads/$thread/runs/$run/steps"
-}
-
-cmd:get-step() {
-  local thread
-  local run
-  local step
-
-  if wants-help "$@" || [ -z "$*" ]; then
-    cmd-usage 'get-step' 'THREAD' 'RUN' 'STEP'
-  fi
-
-  thread=$(get-config --thread "$@") || die "cancel-run: expected --thread"
-  run=$(get-config --run "$@") || die "cancel-run: expected --run"
-  step=$(get-config --step "$@") || die "cancel-run: expected --step"
-
-  request "$API_BASE_URI/threads/$thread/runs/$run/steps/$step"
 }
 
 cmd:get-completion() {

--- a/openai
+++ b/openai
@@ -567,6 +567,8 @@ cmd:add-message() {
   thread=$(get-config --thread "$@") || die "add-message: expected --thread"
   content=$(get-config --content "$@") || die "add-message: expected --content"
 
+  [ -z "$content" ] && die "add-message: Content is empty, cannot send."
+
   payload=$(jq -n '{"role": "user"}')
   payload=$(jq --arg x "$content" '. + {"content": $x}' <<< "$payload")
 

--- a/openai
+++ b/openai
@@ -185,7 +185,7 @@ cmd-usage() {
         ;;
 
       'TOOLS[]')
-        collected+=('--tools' 'the name of tools to enable; can be specified multiple times; current options are "code_interpreter", "retrieval", and "function"')
+        collected+=('--tools' 'the name of tools to enable; can be specified multiple times; current options are "code_interpreter", "file_search", and "function"')
         ;;
 
       *)

--- a/openai
+++ b/openai
@@ -6,8 +6,10 @@ set -eu -o pipefail
 # Global variables
 # ------------------------------------------------------------------------------
 PROGRAM="${0##*/}"
-OPENAI_MODEL="${OPENAI_MODEL:-gpt-3.5-turbo-16k}"
 NOTTY=false
+
+OPENAI_MODEL="${OPENAI_MODEL:-gpt-3.5-turbo-16k}"
+API_BASE_URI="https://api.openai.com/v2"
 
 if [ -t 1 ]; then
   # If stdout is a terminal, use a dark theme by default
@@ -329,7 +331,7 @@ request() {
       "${args[@]}" \
       -H "Authorization: Bearer $OPENAI_API_KEY" \
       -H "Content-Type: application/json" \
-      -H "OpenAI-Beta: assistants=v1"
+      -H "OpenAI-Beta: assistants=v2"
   ) || die "API connection error"
 
   response-ok "$response"
@@ -350,7 +352,7 @@ stream-request() {
     "${args[@]}" \
     -H "Authorization: Bearer $OPENAI_API_KEY" \
     -H "Content-Type: application/json" \
-    -H "OpenAI-Beta: assistants=v1" \
+    -H "OpenAI-Beta: assistants=v2" \
     | while IFS= read -r line; do
       if [[ "$line" == "event: "* ]]; then
         event=${line#event: }
@@ -424,7 +426,7 @@ cmd:list-files() {
     cmd-usage 'list-files'
   fi
 
-  request "https://api.openai.com/v1/files"
+  request "$API_BASE_URI/files"
 }
 
 cmd:get-file() {
@@ -436,7 +438,7 @@ cmd:get-file() {
 
   file_id=$(get-config --file "$@") || die "get-file: expected --file"
 
-  request "https://api.openai.com/v1/files/$file_id"
+  request "$API_BASE_URI/files/$file_id"
 }
 
 cmd:upload-file() {
@@ -515,7 +517,7 @@ cmd:upload-file() {
     mime="text/plain"
   fi
 
-  request https://api.openai.com/v1/files \
+  request "$API_BASE_URI/files" \
     -H 'Content-Type: multipart/form-data' \
     -F purpose="$purpose" \
     -F file="@$file"
@@ -535,7 +537,7 @@ cmd:delete-file() {
 
   file=$(get-config --file "$@") || die "delete-file: expected --file"
 
-  request "https://api.openai.com/v1/files/$file" -X DELETE
+  request "$API_BASE_URI/files/$file" -X DELETE
 }
 
 cmd:retrieve-file() {
@@ -547,7 +549,7 @@ cmd:retrieve-file() {
 
   file=$(get-config --file "$@") || die "retrieve-file: expected --file"
 
-  request "https://api.openai.com/v1/files/$file/content"
+  request "$API_BASE_URI/files/$file/content"
 }
 
 cmd:create-assistant() {
@@ -592,7 +594,7 @@ cmd:create-assistant() {
     payload=$(jq --argjson tools "$(printf '%s\n' "${tools[@]}" | jq -R '{type: .}' | jq -s .)" '. + {tools: $tools}' <<< "$payload")
   fi
 
-  request https://api.openai.com/v1/assistants -d "$payload"
+  request "$API_BASE_URI/assistants" -d "$payload"
 }
 
 cmd:modify-assistant() {
@@ -648,7 +650,7 @@ cmd:modify-assistant() {
     payload=$(jq --argjson tools "$(printf '%s\n' "${tools[@]}" | jq -R '{type: .}' | jq -s .)" '. + {tools: $tools}' <<< "$payload")
   fi
 
-  request "https://api.openai.com/v1/assistants/$assistant" -d "$payload"
+  request "$API_BASE_URI/assistants/$assistant" -d "$payload"
 }
 
 cmd:get-assistant() {
@@ -660,7 +662,7 @@ cmd:get-assistant() {
 
   assistant=$(get-config --assistant "$@") || die "get-assistant: expected --assistant"
 
-  request "https://api.openai.com/v1/assistants/$assistant"
+  request "$API_BASE_URI/assistants/$assistant"
 }
 
 cmd:list-assistants() {
@@ -675,7 +677,7 @@ cmd:list-assistants() {
     cmd-usage 'list-assistants' 'PAGINATION'
   fi
 
-  endpoint=$(build-paginated-uri "https://api.openai.com/v1/assistants" "$@")
+  endpoint=$(build-paginated-uri "$API_BASE_URI/assistants" "$@")
   request "$endpoint"
 }
 
@@ -687,7 +689,7 @@ cmd:delete-assistant() {
   fi
 
   assistant=$(get-config --assistant "$@") || die "delete-assistant: expected --assistant"
-  request "https://api.openai.com/v1/assistants/$assistant" -X DELETE
+  request "$API_BASE_URI/assistants/$assistant" -X DELETE
 }
 
 cmd:add-assistant-file() {
@@ -705,7 +707,7 @@ cmd:add-assistant-file() {
   payload=$(jq -n '{}')
   payload=$(jq --arg x "$file" '. + {"file_id": $x}' <<< "$payload")
 
-  request "https://api.openai.com/v1/assistants/$assistant/files" -d "$payload"
+  request "$API_BASE_URI/assistants/$assistant/files" -d "$payload"
 }
 
 cmd:get-assistant-file() {
@@ -719,7 +721,7 @@ cmd:get-assistant-file() {
   assistant=$(get-config --assistant "$@") || die "get-assistant-file: expected --assistant"
   file=$(get-config --file "$@") || die "get-assistant-file: expected --file"
 
-  request "https://api.openai.com/v1/assistants/$assistant/files/$file"
+  request "$API_BASE_URI/assistants/$assistant/files/$file"
 }
 
 cmd:delete-assistant-file() {
@@ -733,7 +735,7 @@ cmd:delete-assistant-file() {
   assistant=$(get-config --assistant "$@") || die "get-assistant-file: expected --assistant"
   file=$(get-config --file "$@") || die "get-assistant-file: expected --file"
 
-  request "https://api.openai.com/v1/assistants/$assistant/files/$file" -X DELETE
+  request "$API_BASE_URI/assistants/$assistant/files/$file" -X DELETE
 }
 
 cmd:list-assistant-files() {
@@ -750,7 +752,7 @@ cmd:list-assistant-files() {
   fi
 
   assistant=$(get-config --assistant "$@") || die "list-assistant-files: expected --assistant"
-  endpoint=$(build-paginated-uri "https://api.openai.com/v1/assistants/$assistant/files" "$@")
+  endpoint=$(build-paginated-uri "$API_BASE_URI/assistants/$assistant/files" "$@")
 
   request "$endpoint"
 }
@@ -765,7 +767,7 @@ cmd:start-thread() {
   payload=$(jq -n '{}')
   payload-meta payload "$@"
 
-  request https://api.openai.com/v1/threads -d "$payload"
+  request "$API_BASE_URI/threads" -d "$payload"
 }
 
 cmd:modify-thread() {
@@ -781,7 +783,7 @@ cmd:modify-thread() {
   payload=$(jq -n '{}')
   payload-meta payload "$@"
 
-  request "https://api.openai.com/v1/threads/$thread" -d "$payload"
+  request "$API_BASE_URI/threads/$thread" -d "$payload"
 }
 
 cmd:delete-thread() {
@@ -793,7 +795,7 @@ cmd:delete-thread() {
 
   thread=$(get-config --thread "$@") || die "delete-assistant: expected --thread"
 
-  request "https://api.openai.com/v1/threads/$thread" -X DELETE
+  request "$API_BASE_URI/threads/$thread" -X DELETE
 }
 
 cmd:get-thread() {
@@ -805,7 +807,7 @@ cmd:get-thread() {
 
   thread=$(get-config --thread "$@") || die "delete-assistant: expected --thread"
 
-  request "https://api.openai.com/v1/threads/$thread"
+  request "$API_BASE_URI/threads/$thread"
 }
 
 cmd:add-message() {
@@ -830,7 +832,7 @@ cmd:add-message() {
     payload=$(jq --argjson x "$(printf '%s\n' "${files[@]}" | jq -R . | jq -s .)" '. + {file_ids: $x}' <<< "$payload")
   fi
 
-  request "https://api.openai.com/v1/threads/$thread/messages" -d "$payload"
+  request "$API_BASE_URI/threads/$thread/messages" -d "$payload"
 }
 
 cmd:modify-message() {
@@ -848,7 +850,7 @@ cmd:modify-message() {
   payload=$(jq -n '{}')
   payload-meta payload "$@"
 
-  request "https://api.openai.com/v1/threads/$thread/messages/$message" -d "$payload"
+  request "$API_BASE_URI/threads/$thread/messages/$message" -d "$payload"
 }
 
 cmd:get-message() {
@@ -862,7 +864,7 @@ cmd:get-message() {
   thread=$(get-config --thread "$@") || die "get-message: expected --thread"
   message=$(get-config --message "$@") || die "get-message: expected --message"
 
-  request "https://api.openai.com/v1/threads/$thread/messages/$message"
+  request "$API_BASE_URI/threads/$thread/messages/$message"
 }
 
 cmd:list-messages() {
@@ -877,7 +879,7 @@ cmd:list-messages() {
   fi
 
   thread=$(get-config --thread "$@") || die "add-message: expected --thread"
-  endpoint=$(build-paginated-uri "https://api.openai.com/v1/threads/$thread/messages" "$@")
+  endpoint=$(build-paginated-uri "$API_BASE_URI/threads/$thread/messages" "$@")
 
   request "$endpoint"
 }
@@ -894,10 +896,10 @@ cmd:run-thread() {
   thread=$(get-config --thread "$@") || die "run-thread: expected --thread"
 
   if get-flag --stream "$@"; then
-    stream-request "https://api.openai.com/v1/threads/$thread/runs" \
+    stream-request "$API_BASE_URI/threads/$thread/runs" \
       -d "{\"assistant_id\": \"$assistant\", \"stream\": true}"
   else
-    request "https://api.openai.com/v1/threads/$thread/runs" \
+    request "$API_BASE_URI/threads/$thread/runs" \
       -d "{\"assistant_id\": \"$assistant\"}"
   fi
 }
@@ -910,7 +912,7 @@ cmd:list-runs() {
   fi
 
   thread=$(get-config --thread "$@") || die "list-runs: expected --thread"
-  request "https://api.openai.com/v1/threads/$thread/runs"
+  request "$API_BASE_URI/threads/$thread/runs"
 }
 
 cmd:get-run() {
@@ -924,7 +926,7 @@ cmd:get-run() {
   thread=$(get-config --thread "$@") || die "get-run: expected --thread"
   run=$(get-config --run "$@") || die "get-run: expected --run"
 
-  request "https://api.openai.com/v1/threads/$thread/runs/$run"
+  request "$API_BASE_URI/threads/$thread/runs/$run"
 }
 
 cmd:modify-run() {
@@ -942,7 +944,7 @@ cmd:modify-run() {
   payload=$(jq -n '{}')
   payload-meta payload "$@"
 
-  request "https://api.openai.com/v1/threads/$thread/runs/$run" -d "$payload"
+  request "$API_BASE_URI/threads/$thread/runs/$run" -d "$payload"
 }
 
 cmd:cancel-run() {
@@ -956,7 +958,7 @@ cmd:cancel-run() {
   thread=$(get-config --thread "$@") || die "cancel-run: expected --thread"
   run=$(get-config --run "$@") || die "cancel-run: expected --run"
 
-  request "https://api.openai.com/v1/threads/$thread/runs/$run/cancel" -X POST
+  request "$API_BASE_URI/threads/$thread/runs/$run/cancel" -X POST
 }
 
 cmd:list-steps() {
@@ -970,7 +972,7 @@ cmd:list-steps() {
   thread=$(get-config --thread "$@") || die "list-steps: expected --thread"
   run=$(get-config --run "$@") || die "list-steps: expected --run"
 
-  request "https://api.openai.com/v1/threads/$thread/runs/$run/steps"
+  request "$API_BASE_URI/threads/$thread/runs/$run/steps"
 }
 
 cmd:get-step() {
@@ -986,7 +988,7 @@ cmd:get-step() {
   run=$(get-config --run "$@") || die "cancel-run: expected --run"
   step=$(get-config --step "$@") || die "cancel-run: expected --step"
 
-  request "https://api.openai.com/v1/threads/$thread/runs/$run/steps/$step"
+  request "$API_BASE_URI/threads/$thread/runs/$run/steps/$step"
 }
 
 cmd:get-completion() {
@@ -1018,7 +1020,7 @@ cmd:get-completion() {
   payload=$(jq --arg x "$model" '. + {"model": $x}' <<< "$payload")
   payload=$(jq --argjson x "$messages" '. + {"messages": $x}' <<< "$payload")
 
-  request https://api.openai.com/v1/chat/completions -d "$payload"
+  request "$API_BASE_URI/chat/completions" -d "$payload"
 }
 
 main() {

--- a/openai
+++ b/openai
@@ -9,7 +9,8 @@ PROGRAM="${0##*/}"
 NOTTY=false
 
 OPENAI_MODEL="${OPENAI_MODEL:-gpt-3.5-turbo-16k}"
-API_BASE_URI="https://api.openai.com/v2"
+API_BASE_URI="https://api.openai.com/v1"
+API_VERSION_HEADER="OpenAI-Beta: assistants=v2"
 
 if [ -t 1 ]; then
   # If stdout is a terminal, use a dark theme by default
@@ -331,7 +332,7 @@ request() {
       "${args[@]}" \
       -H "Authorization: Bearer $OPENAI_API_KEY" \
       -H "Content-Type: application/json" \
-      -H "OpenAI-Beta: assistants=v2"
+      -H "$API_VERSION_HEADER"
   ) || die "API connection error"
 
   response-ok "$response"


### PR DESCRIPTION
Drops support for v1 file uploads (until I decide whether I have a need for vector stores in these tools). Also drops "run steps" and "tools" (tools being moot without file uploads, and I don't need `function` support at this time).